### PR TITLE
Update project version and modify data specification

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.atmos-system/atmos-logs "3.5"
+(defproject org.clojars.atmos-system/atmos-logs "3.6"
     :description "Log library for atmos system"
     :url "https://github.com/AtmosSystem/Logs"
     :license {:name "Eclipse Public License"

--- a/src/atmos_logs/spec.clj
+++ b/src/atmos_logs/spec.clj
@@ -7,7 +7,7 @@
 (s/def ::message (s/with-gen ::ks/non-blank-string
                              #(gen/fmap (fn [n] (str "A log message" "-" n)) (gen/int))))
 
-(s/def ::extra-data (s/map-of keyword? string?))
+(s/def ::extra-data (s/map-of keyword? any?))
 (s/def ::exception (s/with-gen ::ks/exception
                                #(gen/elements [(Exception.) (InternalError.) (RuntimeException.)])))
 


### PR DESCRIPTION
The project version in the project.clj file has been updated to "3.6". Meanwhile, the `::extra-data` specification in the atmos_logs/spec.clj file has been changed to allow any data type for the map values, rather than just strings.