### PR TITLE
Update atmos-logs version and add logger namespace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.atmos-system/atmos-logs "3.6"
+(defproject org.clojars.atmos-system/atmos-logs "3.7"
     :description "Log library for atmos system"
     :url "https://github.com/AtmosSystem/Logs"
     :license {:name "Eclipse Public License"

--- a/src/atmos_logs/core.clj
+++ b/src/atmos_logs/core.clj
@@ -8,6 +8,7 @@
 
 (defprotocol PLogger
     (logger-name [logger])
+    (logger-ns [logger])
     (log-> [logger log-type data]))
 
 (defprotocol PLoggerActions
@@ -23,6 +24,7 @@
                             #(gen/return (reify
                                              PLogger
                                              (logger-name [_] "Generic logger")
+                                             (logger-ns [_] 'generic.logger)
                                              (log-> [_ _ _] true)
 
                                              PLoggerActions
@@ -40,6 +42,16 @@
 (s/fdef logger-name
         :args (s/cat :logger ::logger)
         :ret string?)
+
+(s/fdef logger-ns
+        :args (s/cat :logger ::logger)
+        :ret symbol?)
+
+(defn logger-valid?
+    [logger]
+    {:pre [(s/valid? string? (logger-name logger))
+           (s/valid? symbol? (logger-ns logger))]}
+    (s/valid? ::logger logger))
 
 (s/fdef log->
         :args (s/cat :logger ::logger :log-type ::log-type ::data ::spec/log-data-or-exception)


### PR DESCRIPTION
Version number was updated in project.clj from 3.6 to 3.7. A namespace function (logger-ns) was introduced in the PLogger protocol, allowing each logger to have an associated namespace. This includes adding a spec for logger-ns and a validity check for logger objects.